### PR TITLE
Add message on empty recommondation

### DIFF
--- a/MMM-WeatherDependentClothes.js
+++ b/MMM-WeatherDependentClothes.js
@@ -23,6 +23,7 @@ Module.register("MMM-WeatherDependentClothes", {
 		forecastResultLimitExtended: 2,
 		
 		logForecastResults: false,
+		displayEmptyMessage: true,
 		
 		units: config.units,
 		updateInterval: 20 * 60 * 1000, // 20 Min
@@ -34,6 +35,7 @@ Module.register("MMM-WeatherDependentClothes", {
 		iconScale: 1, // 1.00 = 100 %
 		iconSize: 64, // px
 		iconSeperator: "extendedForecastSymbol00",
+		
 		// A list of clohtes and conditions to be matched for display
 		preferences: [
 			{
@@ -47,7 +49,7 @@ Module.register("MMM-WeatherDependentClothes", {
 				name: "HeavyRain",
 				icon: "wet",
 				conditions: {
-					rainfall_min: 14,
+					rainfall_min: 14, // mm
 				}
 			},
 			{
@@ -146,7 +148,7 @@ Module.register("MMM-WeatherDependentClothes", {
 				name: "Regenschirm",
 				icon: "umbrella2",
 				conditions: {
-					rainfall_min: 4, // mm
+					rainfall_min: 4,
 				},
 			},
 			{
@@ -212,6 +214,11 @@ Module.register("MMM-WeatherDependentClothes", {
 		
 		if (!this.loaded) {
 			wrapper.innerHTML = this.translate("LOADING");
+			return wrapper;
+		}
+		
+		if (this.config.preferences.length == 0) {
+			wrapper.innerHTML = "The preferences list is empty. Please, add some clothes and conditions.";
 			return wrapper;
 		}
 		
@@ -324,15 +331,14 @@ Module.register("MMM-WeatherDependentClothes", {
 				+ "px; width: auto; display: inline; padding: 0 5px;");
 			wrapper.appendChild(imgSeperator);
 			wrapper.appendChild(forecastExtended);
+		} else if (this.config.displayEmptyMessage && (forecast.children.length == 0)) {
+			wrapper.innerHTML = "<small>No clothing match for current weather.</small>";
 		}
 		
 		// Log forecast data
-		var debugtext = this.temperature + "°C, "
-			+ "rain: "+this.rainfall + "mm, " + 
-			this.weatherType + ", wind:" + this.windSpeed + " m/s, " +
-			"clouds:" +this.cloudDensity + "%";
 		if (this.config.logForecastResults) {
-			Log.log(debugtext);
+			Log.log(this.temperature + "°C, " + "rain: "+this.rainfall + "mm, " + this.weatherType + ", wind:" + 
+					this.windSpeed + " m/s, " + "clouds:" +this.cloudDensity + "%");
 		}
 	
 		return wrapper;
@@ -349,7 +355,6 @@ Module.register("MMM-WeatherDependentClothes", {
 		} else if (this.config.location) {
 			params += "q=" + this.config.location;
 		} else {
-			// this.hide(100, {lockString:this.identifier});
 			return;
 		}
 		

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ The `MMM-WeatherDependentClothes` module is based on the default `currentweather
 - WeatherDependentClothes screenshot
 
 ![WeatherDependentClothes Screenshot 1](screenshot01.png)
+
+In Image 1 the module recommends to take a Jacket, Pants and Shoes with you. This will be sufficient for the next eight hours. After that the weather gets chilly so a winter Jacket and cold protective pants are adviced.
+
 ![WeatherDependentClothes Screenshot 2](screenshot02.png)
+
+Image 2 reminds you to pick up an Umbrella and warns you about some heavy rain later. Take a Raincoat with you or use a Winter Jacket with rainprotection.
+
+The calculaitons for temperature are based on medean values (it could get a bit more chilly/hot) while rainfall is summed up.
 
 ### Installation
 ````
@@ -23,21 +30,28 @@ To use this module, add it to the modules array in the `config/config.js` file:
 modules: [
 	{
 		module: "MMM-WeatherDependentClothes",
-		position: "top_right", // This can be any of the regions.
+		position: "top_right",
 		config: {
 			// See 'Configuration options' for more information.
 			location: "Vienna,Austria",
-			locationID: "", //Location ID from http://bulk.openweathermap.org/sample/city.list.json.gz
-			appid: "abcde12345abcde12345abcde12345ab" //openweathermap.org API key.
+			locationID: "", // Location ID from http://bulk.openweathermap.org/sample/city.list.json.gz
+			appid: "YOUR-API-KEY-HERE", // OpenWeatherMap.org API-Key
 			preferences: [
 				{
-				    name: "Winter jacket",
-				    icon: "jacket-cold",
-				    conditions: {
-					temp_max: 2.0,
-				    }
+					name: "Pants",
+					icon: "pants",
+					conditions: {
+						temp_max: 16.0,
+					},
 				},
-				// more items here. See .js for default list
+				{
+					name: "Shorts",
+					icon: "shorts",
+					conditions: {
+						temp_min: 16.0,
+					},
+				},
+				// add more items here. See .js for default list
 			]
 		}
 	}
@@ -63,9 +77,10 @@ The following properties can be configured:
 | `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
 | `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
 | `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'forecast'`
-| `forecastResultLimit`	           | Defines amount of forecast data sets to be fetched. The clothing preferences are matched against these data sets. <br><br> **Default value:**  `4` <br><br> **Note:** Each data set is three hours apart and the first set may be up to 3 hours old. (e.g. `4` fetches 4*3: forecast of next 9 to 12 hours)
+| `forecastResultLimit`	           | Defines amount of forecast data sets to be fetched. The clothing preferences are matched against these data sets. <br><br> **Default value:**  `3` <br><br> **Note:** Each data set is three hours apart and the first set may be up to 3 hours old. (e.g. `3` fetches 3*3h: forecast of next 6 to 9 hours)
 | `forecastResultLimitExtended`	           | Defines amount of extended forecast data sets to be fetched. <br><br> **Default value:**  `2` <br><br> **Note:** If this is not `0` (Zero) and the weather is significantly changing after the `forecastResultLimit` data sets, additional clothing recommondations are displayed (after the `iconSeperator`).
 | `logForecastResults`	           | Log weatherForecastResults to console if `true`. <br><br> **Default value:**  `false`
+| `displayEmptyMessage`	           | If `true`, a message will inform you that no clothing item matches the current weather. If `false`, the area will stay empty. <br><br> **Default value:**  `true`
 | `iconPath`	           | The path to the icons folder. <br><br> **Default value:**  `'icons/'`
 | `iconScale`	           | Scale of PNG icons (1 stands for 100%). <br><br> **Default value:**  `1`
 | `iconSize`	           | Define iconSize for PNG icons. <br><br> **Default value:**  `64`


### PR DESCRIPTION
Adds a message to notify the user about empty preference list.
Adds a message to notify the user about empty clothing recommondations (#1) if none matches the current weather. `displayEmptyMessage `default value is `true`, can be disabled via  `displayEmptyMessage : false,` in conifg.js

Adds `displayEmptyMessage` description to Configuration options section in readme.md.
Additinoal fix in readme.md and image description